### PR TITLE
Byte position for semi-auto parking in DAE_UDS

### DIFF
--- a/json/DIRECTN/DAE_UDS.json
+++ b/json/DIRECTN/DAE_UDS.json
@@ -97,7 +97,7 @@
       },
       "CFG_EP3_DAE_UDS_CPK_003": {
         "name": "Semi-automatic parking system",
-        "byte": 0,
+        "byte": 1,
         "type": "bool",
         "form_type": "combobox",
         "mask": "00000001",


### PR DESCRIPTION
semi-auto parking for the DAE_UDS module starts from the 2nd byte.

for example
data before enabling semi-auto parking
03CBF7FDFFFFBFFFFFEFFFFBFFFFFF
and after
03CAF7FDFFFFBFFFFFEFFFF7FFFFFF