### PR TITLE
Add additional servicing threshold limits

### DIFF
--- a/json/BMF/BSI2010.json
+++ b/json/BMF/BSI2010.json
@@ -5150,6 +5150,9 @@
         { "value": "7D", "name": "Electric-25000KM" },
         { "value": "64", "name": "Petrol-20000KM" },
         { "value": "4B", "name": "Petrol-15000KM" },
+        { "value": "32", "name": "Petrol-10000KM" },
+        { "value": "23", "name": "Petrol-7000KM" },
+        { "value": "19", "name": "Petrol-5000KM" },
         { "value": "C8", "name": "Diesel-30000KM" }
       ],
       "name": "Servicing threshold(marketing)"


### PR DESCRIPTION
Allow for more frequent service threshold to maintain better lubrication of the timing belt. Tested on my car "Petrol-10000KM". Works well.