### PR TITLE
Wait a few seconds after arduino connection

### DIFF
--- a/SerialPort.py
+++ b/SerialPort.py
@@ -92,7 +92,7 @@ class SerialPort():
                 return "Timeout"
 
             i = data.find(b"\r")
-            decodedData = data[:i].decode("utf-8");
+            decodedData = data[:i].decode("utf-8")
             return decodedData
 
     def sendReceive(self, cmd: str):
@@ -101,4 +101,4 @@ class SerialPort():
         else:
             cmd += "\n"
             self.write(cmd.encode("utf-8"))
-            return self.readData();
+            return self.readData()


### PR DESCRIPTION
Some arduinos are resetting after being connected to. This result in the 'V' command to timeout (ie sent too early while arduino is not ready to handle it). Wait 2 seconds before sending the command so that the arduino is ready to answer. This commit fixes issues #47 which I also encountered.