### PR TITLE
Update BSI2010.json

### DIFF
--- a/json/BMF/BSI2010.json
+++ b/json/BMF/BSI2010.json
@@ -168,7 +168,7 @@
         { "value": "003E", "name": "62 Ohms?" },
         { "value": "0040", "name": "64 Ohms" },
         { "value": "0046", "name": "70 Ohms" }
-         { "value": "0047", "name": "**0x36" }
+        { "value": "0047", "name": "**0x36" }
       ],
       "name": "The resistance of the fuel level sensor with a full tank"
     },


### PR DESCRIPTION
We noticed that the parameter coding value was missing in my 308 GTI T9 vehicle.
![308 GTI jpg](https://github.com/user-attachments/assets/21e43776-885b-424f-89ec-04095acf7386)
