### PR TITLE
Added websocket adapter type

### DIFF
--- a/DiagnosticAdapter.py
+++ b/DiagnosticAdapter.py
@@ -21,7 +21,7 @@ class DiagnosticAdapter:
             self.transport = BluetoothAdapter(logger=self.logger)
 
         elif mode == "websocket":
-            ipAddress = kwargs.get("url", "192.168.100.1")
+            ipAddress = kwargs.get("ipAddress", "192.168.100.1")
             url = "ws://" + ipAddress + "/ws"
             print(f"Using WebSocket URL: {url}")
             self.transport = WebSocketClientTransport(logger=self.logger, url=url)

--- a/DiagnosticAdapter.py
+++ b/DiagnosticAdapter.py
@@ -1,4 +1,5 @@
 import sys
+from WebSocketClientTransport import WebSocketClientTransport
 from SerialPort import SerialPort
 from VCIAdapter import VCIAdapter
 from BluetoothAdapter import BluetoothAdapter
@@ -6,6 +7,7 @@ from BluetoothAdapter import BluetoothAdapter
 class DiagnosticAdapter:
 
     def __init__(self, logger=None, mode="serial", **kwargs):
+        print(f"Initializing DiagnosticAdapter with mode: {mode}")
         self.logger = logger
 
         if mode == "serial":
@@ -17,6 +19,12 @@ class DiagnosticAdapter:
 
         elif mode == "bluetooth":
             self.transport = BluetoothAdapter(logger=self.logger)
+
+        elif mode == "websocket":
+            ipAddress = kwargs.get("url", "192.168.100.1")
+            url = "ws://" + ipAddress + "/ws"
+            print(f"Using WebSocket URL: {url}")
+            self.transport = WebSocketClientTransport(logger=self.logger, url=url)
 
         else:
             raise ValueError("Unknown transport")

--- a/PyPSADiagGUI.py
+++ b/PyPSADiagGUI.py
@@ -23,11 +23,11 @@ import os, json, sys
 from datetime import datetime
 from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
     QMetaObject, QObject, QPoint, QRect,
-    QSize, QTime, QUrl, Qt)
+    QSize, QTime, QUrl, Qt, QRegularExpression)
 from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
-    QPalette, QPixmap, QRadialGradient, QTransform, QAction, QActionGroup)
+    QPalette, QPixmap, QRadialGradient, QTransform, QAction, QActionGroup, QRegularExpressionValidator)
 from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QFrame,
     QHBoxLayout, QLabel, QLineEdit, QMainWindow, QPushButton,
     QSizePolicy, QSpacerItem, QSplitter, QStatusBar,
@@ -137,6 +137,7 @@ class PyPSADiagGUI(object):
 
         self.diagtoolTypeComboBox = QComboBox()
         self.canPinsComboBox = QComboBox()
+        self.wsIpInput = QLineEdit()
         self.portNameComboBox = QComboBox()
         self.ConnectPort = QPushButton()
         self.SearchConnectPort = QPushButton()
@@ -174,6 +175,16 @@ class PyPSADiagGUI(object):
         self.diagtoolTypeComboBox.addItem("ELM327", "bluetooth")
         if sys.platform == "win32":
             self.diagtoolTypeComboBox.addItem("VCI", "vci")
+        self.diagtoolTypeComboBox.addItem("Websocket", "websocket")
+
+        ip_regex = QRegularExpression(r"^(\d{1,3}\.){3}\d{1,3}$")
+        self.wsIpInput.setValidator(QRegularExpressionValidator(ip_regex))
+        self.wsIpInput.setMaxLength(15)
+        fm = self.wsIpInput.fontMetrics()
+        self.wsIpInput.setFixedWidth(fm.horizontalAdvance("0") * 15 + 10)
+        self.wsIpInput.setText("192.168.100.1")
+        self.wsIpInput.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.wsIpInput.setVisible(False)
 
         # Fill CAN Pins Combobox (VCI only)
         self.canPinsComboBox.addItem("Pins 3/8 (AEE)", "DIAG")
@@ -233,6 +244,7 @@ class PyPSADiagGUI(object):
         self.connectionBoxLayout.addWidget(self.diagtoolTypeComboBox)
         self.connectionBoxLayout.addWidget(self.canPinsComboBox)
         self.connectionBoxLayout.addWidget(self.portNameComboBox)
+        self.connectionBoxLayout.addWidget(self.wsIpInput)
         self.connectionBoxLayout.addWidget(self.SearchConnectPort)
         self.connectionBoxLayout.addWidget(self.ConnectPort)
         self.connectionBoxLayout.addWidget(self.DisconnectPort)
@@ -420,4 +432,4 @@ class PyPSADiagGUI(object):
         self.languageMenu.setTitle(i18n().tr("Language"))
 
     def setEcuTxRxText(self, txId: str, rxId: str, protocol: str):
-        self.ecuTxRxLabel.setText("TX: " + str(txId) + " | RX: " + str(rxId) + " | protocol: " + str(protocol)) 
+        self.ecuTxRxLabel.setText("TX: " + str(txId) + " | RX: " + str(rxId) + " | protocol: " + str(protocol))

--- a/WebSocketClientTransport.py
+++ b/WebSocketClientTransport.py
@@ -1,0 +1,142 @@
+#from socket import timeout
+import time
+
+import websocket
+import threading
+import queue
+from PySide6.QtWidgets import QApplication
+
+class WebSocketClientTransport:
+    def __init__(self, logger=None, url=""):
+        self.logger = logger
+        self.url = url
+        self.ws = None
+        self._thread = None
+        self._rx_queue = queue.Queue()
+        self._open = False
+
+    def __del__(self):
+        self.close()
+
+    def isOpen(self):
+        return self._open
+
+    def open(self, portNr=None, baudRate=None, timeout=5.0):
+        if self._open:
+            return ""
+
+        # Create an event to signal when the connection is established
+        self._connection_event = threading.Event()
+
+        def on_message(ws, message):
+            self._rx_queue.put(message)
+
+        def on_open(ws):
+            self._open = True
+            self._connection_event.set()  # Trigger the "switch"
+
+        def on_close(ws, close_status_code, close_msg):
+            self._open = False
+            self._connection_event.clear()
+
+        def on_error(ws, error):
+            if self.logger:
+                print(f"WebSocket Error: {error}")
+                #self.logger(f"WebSocket Error: {error}")
+
+        self.ws = websocket.WebSocketApp(
+            self.url,
+            on_message=on_message,
+            on_open=on_open,
+            on_close=on_close,
+            on_error=on_error
+        )
+
+        self._thread = threading.Thread(target=self.ws.run_forever, daemon=True)
+        self._thread.start()
+
+        start_time = time.time()
+        while not self._open:
+            # Check for timeout
+            if time.time() - start_time > timeout:
+                self.close()
+                # This forces the background thread to stop the OS connect attempt
+                if self.ws:
+                    self.ws.keep_running = False # Tell the loop to stop
+                    self.ws.close()             # Close the socket
+
+                # Don't leave the thread hanging
+                if self._thread and self._thread.is_alive():
+                    self._thread.join(timeout=1.0)
+
+                return f"Failed to connect to {self.url} within {timeout}s"
+
+            # This small sleep allows the OS and other threads to breathe
+            time.sleep(0.1)
+
+            QApplication.processEvents()
+
+        return ""
+
+    def close(self):
+        if self.ws:
+            # This triggers the websocket loop to stop
+            self.ws.close()
+
+        if self._thread and self._thread.is_alive():
+            # Wait for the thread to actually finish
+            self._thread.join(timeout=2.0)
+
+        self._open = False
+        self.ws = None
+
+    def configure(self, tx_id, rx_id, protocol="uds", bus="DIAG", target=None, dialog_type="0"):
+        return True
+
+    def write(self, data):
+        if not self._open:
+            raise RuntimeError("WebSocket not open")
+        self.ws.send(data)
+
+    def readData(self, timeout=5):
+        try:
+            if timeout is None:
+                timeout = 5
+            # .get() is blocking by default.
+            # It will wait until an item is available or 'timeout' seconds pass.
+            end_time = time.time() + timeout
+            while time.time() < end_time:
+                message = self._rx_queue.get(block=True, timeout=timeout)
+                if message is not None:
+                    # If the message is a string, strip \r and \n from both ends
+                    if isinstance(message, str):
+                        return message.strip("\r\n ")
+
+                    # If it's binary (bytes), you can still strip it
+                    if isinstance(message, bytes):
+                        return message.strip(b"\r\n ")
+
+                    return message
+
+            return "Timeout"
+            #message = self._rx_queue.get(block=True, timeout=timeout)
+            #if message is None:
+                #return None
+
+        except queue.Empty:
+            # This triggers if the timeout is reached and the queue is still empty
+            #if self.logger:
+                #self.logger("Read timeout reached")
+            print("Read timeout reached")
+            return "Timeout"
+
+    def sendReceive(self, data, timeout=None):
+        # Clear existing messages in queue
+        while not self._rx_queue.empty():
+            try:
+                self._rx_queue.get_nowait()
+            except queue.Empty:
+                break
+
+        self.write(data)
+        return self.readData(timeout)

--- a/main.py
+++ b/main.py
@@ -143,6 +143,7 @@ class VisioparkCalibrationDialog(QDialog):
 class MainWindow(QMainWindow):
     ui = PyPSADiagGUI()
     ecuObjectList = {}
+    diagtool_type = "serial"
     simulation = False
     scan = False
     flashEnable = False
@@ -279,25 +280,31 @@ class MainWindow(QMainWindow):
         self.updateEcuTxRxLabel()
 
     def changeDiagtoolType(self, index):
-        diagtool_type = self.ui.diagtoolTypeComboBox.itemData(index)
-        if diagtool_type.lower() == "serial" or diagtool_type.lower() == "bluetooth":
+        self.diagtool_type = self.ui.diagtoolTypeComboBox.itemData(index)
+        if self.diagtool_type.lower() == "serial" or self.diagtool_type.lower() == "bluetooth":
             # Arduino and Bluetooth both use COM port selection
             self.ui.portNameComboBox.setEnabled(True)
             self.ui.SearchConnectPort.setEnabled(True)
             self.ui.canPinsComboBox.setVisible(False)
+            self.ui.wsIpInput.setVisible(False)
             if self.ui.portNameComboBox.count() > 0:
                 self.ui.ConnectPort.setEnabled(True)
             else:
                 self.ui.ConnectPort.setEnabled(False)
-        else:
+        elif self.diagtool_type.lower() == "vci":
             # VCI mode - no COM port needed, show CAN pins
             self.ui.portNameComboBox.setEnabled(False)
             self.ui.SearchConnectPort.setEnabled(False)
             self.ui.canPinsComboBox.setVisible(True)
+            self.ui.wsIpInput.setVisible(False)
             self.ui.ConnectPort.setEnabled(True)
-
-        self.serialController = DiagnosticAdapter(logger=self.writeToOutputView, mode=diagtool_type, simulation=self.simulation)
-        self.setupCommunication()
+        elif self.diagtool_type.lower() == "websocket":
+            # Websocket mode - no COM port needed, show IP input
+            self.ui.portNameComboBox.setEnabled(False)
+            self.ui.SearchConnectPort.setEnabled(False)
+            self.ui.canPinsComboBox.setVisible(False)
+            self.ui.wsIpInput.setVisible(True)
+            self.ui.ConnectPort.setEnabled(True)
 
     def loadTranslator(self):
         qm_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "i18n", "translations", f"PyPSADiag_{self.lang_code}.qm")
@@ -386,6 +393,9 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def connectPort(self):
+        self.serialController = DiagnosticAdapter(logger=self.writeToOutputView, mode=self.diagtool_type, simulation=self.simulation, url=self.ui.wsIpInput.text())
+        self.setupCommunication()
+
         # Set begin connecting button states
         self.ui.ConnectPort.setEnabled(False)
         self.ui.DisconnectPort.setEnabled(False)

--- a/main.py
+++ b/main.py
@@ -395,7 +395,7 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def connectPort(self):
-        self.serialController = DiagnosticAdapter(logger=self.writeToOutputView, mode=self.diagtool_type, simulation=self.simulation, url=self.ui.wsIpInput.text())
+        self.serialController = DiagnosticAdapter(logger=self.writeToOutputView, mode=self.diagtool_type, simulation=self.simulation, ipAddress=self.ui.wsIpInput.text())
         self.setupCommunication()
 
         # Set begin connecting button states

--- a/main.py
+++ b/main.py
@@ -285,6 +285,7 @@ class MainWindow(QMainWindow):
             # Arduino and Bluetooth both use COM port selection
             self.ui.portNameComboBox.setEnabled(True)
             self.ui.SearchConnectPort.setEnabled(True)
+            self.ui.portNameComboBox.setVisible(True)
             self.ui.canPinsComboBox.setVisible(False)
             self.ui.wsIpInput.setVisible(False)
             if self.ui.portNameComboBox.count() > 0:
@@ -303,6 +304,7 @@ class MainWindow(QMainWindow):
             self.ui.portNameComboBox.setEnabled(False)
             self.ui.SearchConnectPort.setEnabled(False)
             self.ui.canPinsComboBox.setVisible(False)
+            self.ui.portNameComboBox.setVisible(False)
             self.ui.wsIpInput.setVisible(True)
             self.ui.ConnectPort.setEnabled(True)
 
@@ -420,6 +422,7 @@ class MainWindow(QMainWindow):
             self.ui.portNameComboBox.setEnabled(False)
             self.ui.SearchConnectPort.setEnabled(False)
             self.ui.ConnectPort.setEnabled(False)
+            self.ui.wsIpInput.setEnabled(False)
             self.ui.DisconnectPort.setEnabled(True)
             self.ui.commandsMenu.setEnabled(True)
             self.ui.disableEcoMode.setEnabled(True)
@@ -442,6 +445,7 @@ class MainWindow(QMainWindow):
         self.ui.portNameComboBox.setEnabled(True)
         self.ui.SearchConnectPort.setEnabled(True)
         self.ui.ConnectPort.setEnabled(True)
+        self.ui.wsIpInput.setEnabled(True)
         self.ui.DisconnectPort.setEnabled(False)
 
         self.setEcuCommandsState(False)


### PR DESCRIPTION
I have a PSA related project which is used to retrofit ECUs on the comfort bus (VAN - CAN  and AEE2004 - AEE2010 conversion): https://github.com/morcibacsi/PSAVanCanBridge

To make it possible for the users to configure the retrofitted ECUs my project creates a wifi hotspot and a websocket. It uses the same protocol as the Arduino sketch. 

Later I will backport the websocket to my other project which is a replacement for vluds sketch for the ESP32: https://github.com/morcibacsi/PSADiag

<img width="1202" height="783" alt="image" src="https://github.com/user-attachments/assets/23d5f73a-a928-42ff-bba7-a2e9c6bf8b91" />
