### PR TITLE
Update CIROCCO.json

### DIFF
--- a/json/COMBINE/CIROCCO.json
+++ b/json/COMBINE/CIROCCO.json
@@ -617,7 +617,7 @@
                         },
                         {
                             "mask": "01000000",
-                            "name": "Unknown car 5"
+                            "name": "C5 Aircross (C84)"
                         },
                         {
                             "mask": "01010000",

--- a/json/COMBINE/CIROCCO.json
+++ b/json/COMBINE/CIROCCO.json
@@ -617,7 +617,7 @@
                         },
                         {
                             "mask": "01000000",
-                            "name": "C5 Aircross (C84)"
+                            "name": "C5 Aircross C84 /C5 X7RR Chine"
                         },
                         {
                             "mask": "01010000",

--- a/json/COMBINE/CIROCCO.json
+++ b/json/COMBINE/CIROCCO.json
@@ -617,7 +617,7 @@
                         },
                         {
                             "mask": "01000000",
-                            "name": "C5 Aircross C84 /C5 X7RR Chine"
+                            "name": "C5 Aircross C84 / C5 X7RR Chine"
                         },
                         {
                             "mask": "01010000",


### PR DESCRIPTION
Tested over C84-Project. Minor changes regarding "E70_CMB_CARLINE".
With this value coded, in combination with value coded in "DP5_CMB_OUTLINE", "Other" display C5 Aircross. "Two Box" display C5 X7RR.